### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 


### PR DESCRIPTION
fix a bug:
Could not find com.android.tools.build:gradle:3.3.1.
Searched in the following locations:
    file:/Applications/Android Studio.app/Contents/gradle/m2repository/com/android/tools/build/gradle/3.3.1/gradle-3.3.1.pom
    file:/Applications/Android Studio.app/Contents/gradle/m2repository/com/android/tools/build/gradle/3.3.1/gradle-3.3.1.jar
    https://jcenter.bintray.com/com/android/tools/build/gradle/3.3.1/gradle-3.3.1.pom
    https://jcenter.bintray.com/com/android/tools/build/gradle/3.3.1/gradle-3.3.1.jar
Required by:
    project :react-native-audio-recorder-player
Open File