### PR TITLE
Update podspec for RN 0.60

### DIFF
--- a/ios/RNAudioRecorderPlayer.podspec
+++ b/ios/RNAudioRecorderPlayer.podspec
@@ -4,8 +4,8 @@ package = JSON.parse(File.read('../package.json'))
 Pod::Spec.new do |s|
   s.name         = "RNAudioRecorderPlayer"
   s.version      = package["version"]
-  s.summary      = package["description"]
-  s.description  = <<-DESC
+  s.description  = package["description"]
+  s.summary  = <<-DESC
                   RNAudioRecorderPlayer
                    DESC
   s.homepage     = "https://github.com/dooboolab/react-native-audio-recorder-player"

--- a/ios/RNAudioRecorderPlayer.podspec
+++ b/ios/RNAudioRecorderPlayer.podspec
@@ -1,17 +1,19 @@
+require 'json'
+package = JSON.parse(File.read('../package.json'))
 
 Pod::Spec.new do |s|
   s.name         = "RNAudioRecorderPlayer"
-  s.version      = "1.0.0"
-  s.summary      = "RNAudioRecorderPlayer"
+  s.version      = package["version"]
+  s.summary      = package["description"]
   s.description  = <<-DESC
                   RNAudioRecorderPlayer
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/dooboolab/react-native-audio-recorder-player"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNAudioRecorderPlayer.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/dooboolab/react-native-audio-recorder-player.git", :tag => "master" }
   s.source_files  = "RNAudioRecorderPlayer/**/*.{h,m}"
   s.requires_arc = true
 


### PR DESCRIPTION
Updated the podspec to work with react native 0.60+. While installing I got an error from cocoapods because the homepage was not filled. Also noticed that the podspec was outdated as the version was still on `1.0.0` so I fixed that aswell.