### PR TITLE
Makes path param in startRecord to behave as a path on iOS

### DIFF
--- a/ios/RNAudioRecorderPlayer.m
+++ b/ios/RNAudioRecorderPlayer.m
@@ -116,7 +116,7 @@ RCT_EXPORT_METHOD(startRecorder:(NSString*)path
   if ([path isEqualToString:@"DEFAULT"]) {
     audioFileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingString:@"sound.m4a"]];
   } else {
-    audioFileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingString:path]];
+    audioFileURL = [NSURL fileURLWithPath: path];
   }
 
   NSDictionary *audioSettings = [NSDictionary dictionaryWithObjectsAndKeys:


### PR DESCRIPTION
The path parameter of the method startRecord behaves as a path on Android, where you can pass for example 'sdcard/hello.mp4'. On iOS it was only supporting the fileName, this fix makes the function consistent between iOS and Android, both now can take a path.

Fixes #90