### PR TITLE
add custom path for ios

### DIFF
--- a/ios/RNAudioRecorderPlayer.m
+++ b/ios/RNAudioRecorderPlayer.m
@@ -261,8 +261,14 @@ RCT_EXPORT_METHOD(startPlayer:(NSString*)path
         if ([path isEqualToString:@"DEFAULT"]) {
           audioFileURL = [NSURL fileURLWithPath:[GetDirectoryOfType_Sound(NSCachesDirectory) stringByAppendingString:@"sound.m4a"]];
         } else {
-          audioFileURL = [NSURL fileURLWithPath: [GetDirectoryOfType_Sound(NSCachesDirectory) stringByAppendingString:path]];
+            if ([path rangeOfString:@"file://"].location == NSNotFound) {
+                audioFileURL = [NSURL fileURLWithPath: [GetDirectoryOfType_Sound(NSCachesDirectory) stringByAppendingString:path]];
+            } else {
+                audioFileURL = [NSURL URLWithString:path];
+            }
         }
+                
+        NSLog(@"Error %@",error);
 
         if (!audioPlayer) {
             RCTLogInfo(@"audio player alloc");


### PR DESCRIPTION
update:
add custom path for ios in `startPlayer` method. Currently, `startPlayer` only accepts file name with the default parent directory (Cache Directory). So I add the condition to check if `path` contains `file://` then use `path`, else append default parent directory into path file.