### PR TITLE
Handle stop once player is paused

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -102,6 +102,7 @@ const pad = (num: number): string => {
 class AudioRecorderPlayer {
   private _isRecording: boolean;
   private _isPlaying: boolean;
+  private _isPause: boolean;
   private _recorderSubscription: EmitterSubscription;
   private _playerSubscription: EmitterSubscription;
   private _recordInterval: number;
@@ -214,8 +215,9 @@ class AudioRecorderPlayer {
    * @returns {Promise<string>}
    */
   resumePlayer = async (): Promise<string> => {
-    if (!this._isPlaying) {
-      this._isPlaying = true;
+    if (!this._isPlaying) return 'No audio playing';
+    if (this._isPause) {
+      this._isPause = false;
       return RNAudioRecorderPlayer.resumePlayer();
     }
     return 'Already playing';
@@ -230,8 +232,9 @@ class AudioRecorderPlayer {
     if (!uri) {
       uri = 'DEFAULT';
     }
-    if (!this._isPlaying) {
+    if (!this._isPlaying || this._isPause) {
       this._isPlaying = true;
+      this._isPause = false;
       return RNAudioRecorderPlayer.startPlayer(uri);
     }
   };
@@ -243,6 +246,7 @@ class AudioRecorderPlayer {
   stopPlayer = async (): Promise<string> => {
     if (this._isPlaying) {
       this._isPlaying = false;
+      this._isPause = false;
       return RNAudioRecorderPlayer.stopPlayer();
     }
     return 'Already stopped playing';
@@ -253,8 +257,9 @@ class AudioRecorderPlayer {
    * @returns {Promise<string>}
    */
   pausePlayer = async (): Promise<string> => {
-    if (this._isPlaying) {
-      this._isPlaying = false;
+    if (!this._isPlaying) return 'No audio playing';
+    if (!this._isPause) {
+      this._isPause = true;
       return RNAudioRecorderPlayer.pausePlayer();
     }
   };

--- a/index.ts
+++ b/index.ts
@@ -102,7 +102,7 @@ const pad = (num: number): string => {
 class AudioRecorderPlayer {
   private _isRecording: boolean;
   private _isPlaying: boolean;
-  private _isPause: boolean;
+  private _hasPaused: boolean;
   private _recorderSubscription: EmitterSubscription;
   private _playerSubscription: EmitterSubscription;
   private _recordInterval: number;
@@ -216,8 +216,8 @@ class AudioRecorderPlayer {
    */
   resumePlayer = async (): Promise<string> => {
     if (!this._isPlaying) return 'No audio playing';
-    if (this._isPause) {
-      this._isPause = false;
+    if (this._hasPaused) {
+      this._hasPaused = false;
       return RNAudioRecorderPlayer.resumePlayer();
     }
     return 'Already playing';
@@ -232,9 +232,9 @@ class AudioRecorderPlayer {
     if (!uri) {
       uri = 'DEFAULT';
     }
-    if (!this._isPlaying || this._isPause) {
+    if (!this._isPlaying || this._hasPaused) {
       this._isPlaying = true;
-      this._isPause = false;
+      this._hasPaused = false;
       return RNAudioRecorderPlayer.startPlayer(uri);
     }
   };
@@ -246,7 +246,7 @@ class AudioRecorderPlayer {
   stopPlayer = async (): Promise<string> => {
     if (this._isPlaying) {
       this._isPlaying = false;
-      this._isPause = false;
+      this._hasPaused = false;
       return RNAudioRecorderPlayer.stopPlayer();
     }
     return 'Already stopped playing';
@@ -258,8 +258,8 @@ class AudioRecorderPlayer {
    */
   pausePlayer = async (): Promise<string> => {
     if (!this._isPlaying) return 'No audio playing';
-    if (!this._isPause) {
-      this._isPause = true;
+    if (!this._hasPaused) {
+      this._hasPaused = true;
       return RNAudioRecorderPlayer.pausePlayer();
     }
   };

--- a/ios/RNAudioRecorderPlayer.m
+++ b/ios/RNAudioRecorderPlayer.m
@@ -261,8 +261,14 @@ RCT_EXPORT_METHOD(startPlayer:(NSString*)path
         if ([path isEqualToString:@"DEFAULT"]) {
           audioFileURL = [NSURL fileURLWithPath:[GetDirectoryOfType_Sound(NSCachesDirectory) stringByAppendingString:@"sound.m4a"]];
         } else {
-          audioFileURL = [NSURL fileURLWithPath: [GetDirectoryOfType_Sound(NSCachesDirectory) stringByAppendingString:path]];
+            if ([path rangeOfString:@"file://"].location == NSNotFound) {
+                audioFileURL = [NSURL fileURLWithPath: [GetDirectoryOfType_Sound(NSCachesDirectory) stringByAppendingString:path]];
+            } else {
+                audioFileURL = [NSURL URLWithString:path];
+            }
         }
+                
+        NSLog(@"Error %@",error);
 
         if (!audioPlayer) {
             RCTLogInfo(@"audio player alloc");


### PR DESCRIPTION
Issue:

currently, there is only one flag to define player playing or not. The issue is once user pauses audio player, then change audio player path/uri, the audio player play previous path/uri because audio player does not stop/unset properly.

So, in this PR I add new flag to define is player pause.

note: this PR also contains my previous PR related to `add custom path for ios` (https://github.com/dooboolab/react-native-audio-recorder-player/pull/168).