### PR TITLE
Replicate change of PR #168 into startRecorder

### DIFF
--- a/ios/RNAudioRecorderPlayer.m
+++ b/ios/RNAudioRecorderPlayer.m
@@ -127,9 +127,13 @@ RCT_EXPORT_METHOD(startRecorder:(NSString*)path
   NSNumber *audioQuality = [RCTConvert NSNumber:audioSets[@"AVEncoderAudioQualityKeyIOS"]];
 
   if ([path isEqualToString:@"DEFAULT"]) {
-    audioFileURL = [NSURL fileURLWithPath:[GetDirectoryOfType_Sound(NSCachesDirectory) stringByAppendingString:@"sound.m4a"]];
+      audioFileURL = [NSURL fileURLWithPath:[GetDirectoryOfType_Sound(NSCachesDirectory) stringByAppendingString:@"sound.m4a"]];
   } else {
-    audioFileURL = [NSURL fileURLWithPath: [GetDirectoryOfType_Sound(NSCachesDirectory) stringByAppendingString:path]];
+      if ([path rangeOfString:@"file://"].location == NSNotFound) {
+          audioFileURL = [NSURL fileURLWithPath: [GetDirectoryOfType_Sound(NSCachesDirectory) stringByAppendingString:path]];
+      } else {
+          audioFileURL = [NSURL URLWithString:path];
+      }
   }
 
   if (!sampleRate) {


### PR DESCRIPTION
PR #168 fixed the possibility to add a custom path on iOS, but only for startPlayer, the same code is in startRecorder, so I replicated the change in that method also.