### PR TITLE
Adding optional volume metering

### DIFF
--- a/android/src/main/java/com/dooboolab/RNAudioRecorderPlayerModule.java
+++ b/android/src/main/java/com/dooboolab/RNAudioRecorderPlayerModule.java
@@ -42,6 +42,7 @@ public class RNAudioRecorderPlayerModule extends ReactContextBaseJavaModule impl
   private String audioFileURL = "";
 
   private int subsDurationMillis = 100;
+  private boolean _meteringEnabled = false;
 
   private final ReactApplicationContext reactContext;
   private MediaRecorder mediaRecorder;
@@ -63,7 +64,7 @@ public class RNAudioRecorderPlayerModule extends ReactContextBaseJavaModule impl
   }
 
   @ReactMethod
-  public void startRecorder(final String path, final ReadableMap audioSet, Promise promise) {
+  public void startRecorder(final String path, final Boolean meteringEnabled, final ReadableMap audioSet, Promise promise) {
     try {
       if (
           Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
@@ -86,6 +87,7 @@ public class RNAudioRecorderPlayerModule extends ReactContextBaseJavaModule impl
     }
 
     audioFileURL = (path.equals("DEFAULT")) ? FILE_LOCATION : path;
+    _meteringEnabled = meteringEnabled;
 
     if (mediaRecorder == null) {
       mediaRecorder = new MediaRecorder();
@@ -116,6 +118,18 @@ public class RNAudioRecorderPlayerModule extends ReactContextBaseJavaModule impl
           long time = SystemClock.elapsedRealtime() - systemTime;
           WritableMap obj = Arguments.createMap();
           obj.putDouble("current_position", time);
+          int maxAmplitude = 0;
+          if (mediaRecorder != null) {
+            maxAmplitude = mediaRecorder.getMaxAmplitude();
+
+          }
+          double dB = -160;
+          double maxAudioSize = 32767;
+          if (maxAmplitude > 0){
+            dB = 20 * Math.log10(maxAmplitude / maxAudioSize);
+          }
+
+          obj.putInt("current_metering", (int) dB);
           sendEvent(reactContext, "rn-recordback", obj);
           recordHandler.postDelayed(this, subsDurationMillis);
         }

--- a/android/src/main/java/com/dooboolab/RNAudioRecorderPlayerModule.java
+++ b/android/src/main/java/com/dooboolab/RNAudioRecorderPlayerModule.java
@@ -118,18 +118,20 @@ public class RNAudioRecorderPlayerModule extends ReactContextBaseJavaModule impl
           long time = SystemClock.elapsedRealtime() - systemTime;
           WritableMap obj = Arguments.createMap();
           obj.putDouble("current_position", time);
-          int maxAmplitude = 0;
-          if (mediaRecorder != null) {
-            maxAmplitude = mediaRecorder.getMaxAmplitude();
+          if (_meteringEnabled) {
+            int maxAmplitude = 0;
+            if (mediaRecorder != null) {
+              maxAmplitude = mediaRecorder.getMaxAmplitude();
 
-          }
-          double dB = -160;
-          double maxAudioSize = 32767;
-          if (maxAmplitude > 0){
-            dB = 20 * Math.log10(maxAmplitude / maxAudioSize);
-          }
+            }
+            double dB = -160;
+            double maxAudioSize = 32767;
+            if (maxAmplitude > 0){
+              dB = 20 * Math.log10(maxAmplitude / maxAudioSize);
+            }
 
-          obj.putInt("current_metering", (int) dB);
+            obj.putInt("current_metering", (int) dB);
+          }
           sendEvent(reactContext, "rn-recordback", obj);
           recordHandler.postDelayed(this, subsDurationMillis);
         }

--- a/index.ts
+++ b/index.ts
@@ -185,15 +185,19 @@ class AudioRecorderPlayer {
    */
   startRecorder = async (
     uri?: string,
+    meteringEnabled?: boolean,
     audioSets?: AudioSet,
   ): Promise<string> => {
     if (!uri) {
       uri = 'DEFAULT';
     }
+    if (!meteringEnabled) {
+      meteringEnabled = false;
+    }
 
     if (!this._isRecording) {
       this._isRecording = true;
-      return RNAudioRecorderPlayer.startRecorder(uri, audioSets);
+      return RNAudioRecorderPlayer.startRecorder(uri, meteringEnabled, audioSets);
     }
     return 'Already recording';
   };

--- a/ios/RNAudioRecorderPlayer.m
+++ b/ios/RNAudioRecorderPlayer.m
@@ -195,7 +195,7 @@ RCT_EXPORT_METHOD(startRecorder:(NSString*)path
 
   // Setup audio session
   AVAudioSession *session = [AVAudioSession sharedInstance];
-  [session setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+  [session setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionAllowBluetooth error:nil];
 
   // set volume default to speaker
   UInt32 doChangeDefaultRoute = 1;

--- a/ios/RNAudioRecorderPlayer.m
+++ b/ios/RNAudioRecorderPlayer.m
@@ -21,13 +21,13 @@ NSString* GetDirectoryOfType_Sound(NSSearchPathDirectory dir) {
   AVAudioPlayer *audioPlayer;
   NSTimer *recordTimer;
   NSTimer *playTimer;
+  BOOL _meteringEnabled;
 }
 double subscriptionDuration = 0.1;
 
 - (void)audioPlayerDidFinishPlaying:(AVAudioPlayer *)player successfully:(BOOL)flag {
   NSLog(@"audioPlayerDidFinishPlaying");
   NSNumber *duration = [NSNumber numberWithDouble:audioPlayer.duration * 1000];
-  NSNumber *currentTime = [NSNumber numberWithDouble:audioPlayer.duration * 1000];
 
   // Send last event then finish it.
   // NSString* status = [NSString stringWithFormat:@"{\"duration\": \"%@\", \"current_position\": \"%@\"}", [duration stringValue], [currentTime stringValue]];
@@ -46,8 +46,15 @@ double subscriptionDuration = 0.1;
 {
   NSNumber *currentTime = [NSNumber numberWithDouble:audioRecorder.currentTime * 1000];
   // NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}", [currentTime stringValue]];
+  NSNumber *currentMetering = [NSNumber numberWithDouble:0];
+  if (_meteringEnabled) {
+      [audioRecorder updateMeters];
+      currentMetering = [NSNumber numberWithDouble:[audioRecorder averagePowerForChannel: 0]];
+  }
+
   NSDictionary *status = @{
                          @"current_position" : [currentTime stringValue],
+                         @"current_metering" : [currentMetering stringValue],
                          };
   [self sendEventWithName:@"rn-recordback" body:status];
 }
@@ -64,7 +71,7 @@ double subscriptionDuration = 0.1;
     [audioPlayer stop];
     return;
   }
-  
+
   // NSString* status = [NSString stringWithFormat:@"{\"duration\": \"%@\", \"current_position\": \"%@\"}", [duration stringValue], [currentTime stringValue]];
   NSDictionary *status = @{
                          @"duration" : [duration stringValue],
@@ -116,6 +123,7 @@ RCT_EXPORT_METHOD(setSubscriptionDuration:(double)duration
 }
 
 RCT_EXPORT_METHOD(startRecorder:(NSString*)path
+                  meteringEnabled:(BOOL)meteringEnabled
                   audioSets: (NSDictionary*)audioSets
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
@@ -125,6 +133,7 @@ RCT_EXPORT_METHOD(startRecorder:(NSString*)path
   NSNumber *numberOfChannel = [RCTConvert NSNumber:audioSets[@"AVNumberOfChannelsKeyIOS"]];
   NSNumber *avFormat;
   NSNumber *audioQuality = [RCTConvert NSNumber:audioSets[@"AVEncoderAudioQualityKeyIOS"]];
+  _meteringEnabled = meteringEnabled;
 
   if ([path isEqualToString:@"DEFAULT"]) {
       audioFileURL = [NSURL fileURLWithPath:[GetDirectoryOfType_Sound(NSCachesDirectory) stringByAppendingString:@"sound.m4a"]];
@@ -196,11 +205,12 @@ RCT_EXPORT_METHOD(startRecorder:(NSString*)path
                         initWithURL:audioFileURL
                         settings:audioSettings
                         error:nil];
-  
+  audioRecorder.meteringEnabled = _meteringEnabled;
+
   [audioRecorder setDelegate:self];
   [audioRecorder record];
   [self startRecorderTimer];
-    
+
   NSString *filePath = self->audioFileURL.absoluteString;
   resolve(filePath);
 }
@@ -271,7 +281,7 @@ RCT_EXPORT_METHOD(startPlayer:(NSString*)path
                 audioFileURL = [NSURL URLWithString:path];
             }
         }
-                
+
         NSLog(@"Error %@",error);
 
         if (!audioPlayer) {
@@ -333,7 +343,7 @@ RCT_EXPORT_METHOD(pausePlayer: (RCTPromiseResolveBlock)resolve
         if (playTimer != nil) {
             [playTimer invalidate];
             playTimer = nil;
-        } 
+        }
         resolve(@"pause play");
     } else {
         reject(@"audioPlayer pause", @"audioPlayer is not playing", nil);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.1",
   "description": "React Native Audio Recorder and Player.",
   "homepage": "https://github.com/dooboolab/react-native-audio-recorder-player",
-  "main": "index.js",
+  "main": "index.ts",
   "types": "index.d.ts",
   "postinstall": "dooboolab-welcome postinstall",
   "scripts": {


### PR DESCRIPTION
Adding optional volume tracking as part of RecordBackListener for both iOS and Android.
Implementation was inspired by https://github.com/jsierles/react-native-audio and https://github.com/jsierles/react-native-audio/pull/347

also fixed 1 minor bug - changed `"main": "index.js",` to `"main": "index.ts",` in package.json.

it's important to mention this changes the API (adding argument for startRecorder function)

can solve #73