### PR TITLE
Play music in bluetooth earpiece while recording

### DIFF
--- a/ios/RNAudioRecorderPlayer.m
+++ b/ios/RNAudioRecorderPlayer.m
@@ -186,7 +186,7 @@ RCT_EXPORT_METHOD(startRecorder:(NSString*)path
 
   // Setup audio session
   AVAudioSession *session = [AVAudioSession sharedInstance];
-  [session setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+  [session setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionAllowBluetooth error:nil];
 
   // set volume default to speaker
   UInt32 doChangeDefaultRoute = 1;


### PR DESCRIPTION
When starting to record while playing music It was constantly playing the music from the phone music and not Bluetooth earpiece.
Found that adding AVAudioSessionCategoryOptionAllowBluetooth option solves this