### PR TITLE
fixing mergeExtDexDebugAndroidTest task

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,10 @@ android {
     versionCode 1
     versionName "1.0"
   }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
   lintOptions {
     abortOnError false
   }


### PR DESCRIPTION
running mergeExtDexDebugAndroidTest task failed. fixed it as described [here](https://stackoverflow.com/questions/49512629/default-interface-methods-are-only-supported-starting-with-android-n/49525685#49525685) and implemented [here](https://github.com/proyecto26/react-native-inappbrowser/pull/146)