### PR TITLE
Add try catch block on mediaRecorder.stop()

### DIFF
--- a/android/src/main/java/com/dooboolab/RNAudioRecorderPlayerModule.java
+++ b/android/src/main/java/com/dooboolab/RNAudioRecorderPlayerModule.java
@@ -161,7 +161,12 @@ public class RNAudioRecorderPlayerModule extends ReactContextBaseJavaModule impl
       promise.reject("stopRecord", "recorder is null.");
       return;
     }
-    mediaRecorder.stop();
+    try {
+      mediaRecorder.stop();
+    } catch(RuntimeException stopException) {
+      Log.d(TAG, stopException.getMessage());
+    }
+
     mediaRecorder.release();
     mediaRecorder = null;
 


### PR DESCRIPTION
## Description
The mediarecorder on android fails to stop when recording time is less than a second, causing this "stop failed" error to show.

fixes #203
fixes #199