### PR TITLE
onStartPlay unnecessary code

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,10 +275,6 @@ onStartPlay = async () => {
   const msg = await this.audioRecorderPlayer.startPlayer();
   console.log(msg);
   this.audioRecorderPlayer.addPlayBackListener((e) => {
-    if (e.current_position === e.duration) {
-      console.log('finished');
-      this.audioRecorderPlayer.stopPlayer();
-    }
     this.setState({
       currentPositionSec: e.current_position,
       currentDurationSec: e.duration,


### PR DESCRIPTION
When I check android part of the package there is this code
```
public void onCompletion(MediaPlayer mp) {
          /**
           * Send last event
           */
          WritableMap obj = Arguments.createMap();
          obj.putInt("duration", mp.getDuration());
          obj.putInt("current_position", mp.getDuration());
          sendEvent(reactContext, "rn-playback", obj);

          /**
           * Reset player.
           */
          Log.d(TAG, "Plays completed.");
          mTimer.cancel();
          mp.stop();
          mp.release();
          mediaPlayer = null;
  }
```
Which makes mediaPlayer null when playing is ended. So if we write below code to onStartPlay it will try to stop mediaPlayer that is already null and its will give warning "mediaPlayer is null".

if (e.current_position === e.duration) {
      console.log('finished');
      this.audioRecorderPlayer.stopPlayer();
    }