### PR TITLE
Add promise reject in stop record

### DIFF
--- a/android/src/main/java/com/dooboolab/RNAudioRecorderPlayerModule.java
+++ b/android/src/main/java/com/dooboolab/RNAudioRecorderPlayerModule.java
@@ -169,6 +169,7 @@ public class RNAudioRecorderPlayerModule extends ReactContextBaseJavaModule impl
       mediaRecorder.stop();
     } catch(RuntimeException stopException) {
       Log.d(TAG, stopException.getMessage());
+      promise.reject("stopRecord",stopException.getMessage());
     }
 
     mediaRecorder.release();


### PR DESCRIPTION
I faced a case that the app crashed if I try to start recording while another app is using microphone, app is crashing and I can't catch the error so I inform the user that some thing is happening.
when I traced the error I found that there is an error in stop record function but because there is not promise reject in the catch, so I can't get the error my side.
so I added this promise reject statement in android , and I hope to be able to add similar thing to ios n the future.