### PR TITLE
Support for Linear PCM format settings

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -85,12 +85,23 @@ export enum AVEncoderAudioQualityIOSType {
   max = 127,
 }
 
+export enum AVLinearPCMBitDepthKeyIOSType {
+  'bit8' = 8,
+  'bit16' = 16,
+  'bit24' = 24,
+  'bit32' = 32,
+}
+
 export interface AudioSet {
   AVSampleRateKeyIOS?: number;
   AVFormatIDKeyIOS?: AVEncodingType;
   AVNumberOfChannelsKeyIOS?: number;
   AVEncoderAudioQualityKeyIOS?: AVEncoderAudioQualityIOSType;
   AudioSourceAndroid?: AudioSourceAndroidType;
+  AVLinearPCMBitDepthKeyIOS?: AVLinearPCMBitDepthKeyIOSType;
+  AVLinearPCMIsBigEndianKeyIOS?: boolean;
+  AVLinearPCMIsFloatKeyIOS?: boolean;
+  AVLinearPCMIsNonInterleavedIOS?: boolean;
   OutputFormatAndroid?: OutputFormatAndroidType;
   AudioEncoderAndroid?: AudioEncoderAndroidType;
   AudioEncodingBitRateAndroid?: number;

--- a/ios/RNAudioRecorderPlayer.m
+++ b/ios/RNAudioRecorderPlayer.m
@@ -134,6 +134,10 @@ RCT_EXPORT_METHOD(startRecorder:(NSString*)path
   NSNumber *avFormat;
   NSNumber *audioQuality = [RCTConvert NSNumber:audioSets[@"AVEncoderAudioQualityKeyIOS"]];
   _meteringEnabled = meteringEnabled;
+  NSNumber *avLPCMBitDepth = [RCTConvert NSNumber:audioSets[@"AVLinearPCMBitDepthKeyIOS"]];
+  BOOL *avLPCMIsBigEndian = [RCTConvert BOOL:audioSets[@"AVLinearPCMIsBigEndianKeyIOS"]];
+  BOOL *avLPCMIsFloatKey = [RCTConvert BOOL:audioSets[@"AVLinearPCMIsFloatKeyIOS"]];
+  BOOL *avLPCMIsNonInterleaved = [RCTConvert BOOL:audioSets[@"AVLinearPCMIsNonInterleavedIOS"]];
 
   if ([path isEqualToString:@"DEFAULT"]) {
       audioFileURL = [NSURL fileURLWithPath:[GetDirectoryOfType_Sound(NSCachesDirectory) stringByAppendingString:@"sound.m4a"]];
@@ -191,6 +195,10 @@ RCT_EXPORT_METHOD(startRecorder:(NSString*)path
                                  avFormat, AVFormatIDKey,
                                  numberOfChannel, AVNumberOfChannelsKey,
                                  audioQuality, AVEncoderAudioQualityKey,
+                                 avLPCMBitDepth, AVLinearPCMBitDepthKey,
+                                 avLPCMIsBigEndian, AVLinearPCMIsBigEndianKey,
+                                 avLPCMIsFloatKey, AVLinearPCMIsFloatKey,
+                                 avLPCMIsNonInterleaved, AVLinearPCMIsNonInterleaved,
                                  nil];
 
   // Setup audio session


### PR DESCRIPTION
This PR is related to issue #264

## Notes

The keys of `AVLinearPCMBitDepthKeyIOSType` are named `'bit8'`, `'bit16'`, and so on because the others names (as shown below) that I come up with will cause parsing to fail.

```ts
'8-bit' // Originally intended
'8bit'  // Without dash
'bit8'  // Alphabet as first character
```

Since according to [the docs](https://developer.apple.com/documentation/avfaudio/avlinearpcmbitdepthkey?language=objc), the accepted values are one of 8, 16, 24, and 32 only, I figured it'd be logical to make it an enum instead of a `number` type.

Also, I made this PR from my own `master` branch after forking it since I'm unable to find a `dev` branch as mentioned in `CONTRIBUTING.md`.