### PR TITLE
Add support for audio recording interruptions with segmentation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -293,14 +293,19 @@ class AudioRecorderPlayer {
 
   /**
    * stop recording.
+   * @param {boolean} returnSegments - If true, return comma-separated list of segment file paths (iOS only)
    * @returns {Promise<string>}
    */
-  stopRecorder = async (): Promise<string> => {
+  stopRecorder = async (returnSegments?: boolean): Promise<string> => {
     if (this._isRecording) {
       this._isRecording = false;
       this._hasPausedRecord = false;
 
-      return RNAudioRecorderPlayer.stopRecorder();
+      if (returnSegments !== undefined) {
+        return RNAudioRecorderPlayer.stopRecorder(returnSegments);
+      } else {
+        return RNAudioRecorderPlayer.stopRecorderWithNoOptions();
+      }
     }
 
     return 'Already stopped';

--- a/index.ts
+++ b/index.ts
@@ -157,13 +157,13 @@ export type PlayBackType = {
 };
 
 class AudioRecorderPlayer {
-  private _isRecording: boolean;
-  private _isPlaying: boolean;
-  private _hasPaused: boolean;
-  private _hasPausedRecord: boolean;
-  private _recorderSubscription: EmitterSubscription;
-  private _playerSubscription: EmitterSubscription;
-  private _playerCallback: (event: PlayBackType) => void;
+  private _isRecording: boolean = false;
+  private _isPlaying: boolean = false;
+  private _hasPaused: boolean = false;
+  private _hasPausedRecord: boolean = false;
+  private _recorderSubscription: EmitterSubscription | null = null;
+  private _playerSubscription: EmitterSubscription | null = null;
+  private _playerCallback: ((event: PlayBackType) => void) | null = null;
 
   mmss = (secs: number): string => {
     let minutes = Math.floor(secs / 60);
@@ -379,6 +379,8 @@ class AudioRecorderPlayer {
 
       return RNAudioRecorderPlayer.startPlayer(uri, httpHeaders);
     }
+
+    return 'Already playing';
   };
 
   /**
@@ -410,6 +412,8 @@ class AudioRecorderPlayer {
 
       return RNAudioRecorderPlayer.pausePlayer();
     }
+
+    return 'Already paused playing';
   };
 
   /**

--- a/index.ts
+++ b/index.ts
@@ -301,14 +301,14 @@ class AudioRecorderPlayer {
       this._isRecording = false;
       this._hasPausedRecord = false;
 
-      if (Platform.OS === 'android') {
-        return RNAudioRecorderPlayer.stopRecorder();
-      }
-
       if (returnSegments !== undefined) {
         return RNAudioRecorderPlayer.stopRecorder(returnSegments);
       } else {
-        return RNAudioRecorderPlayer.stopRecorderWithNoOptions();
+        if (Platform.OS === 'android') {
+          return RNAudioRecorderPlayer.stopRecorder();
+        } else {
+          return RNAudioRecorderPlayer.stopRecorderWithNoOptions();
+        }
       }
     }
 

--- a/index.ts
+++ b/index.ts
@@ -301,6 +301,10 @@ class AudioRecorderPlayer {
       this._isRecording = false;
       this._hasPausedRecord = false;
 
+      if (Platform.OS === 'android') {
+        return RNAudioRecorderPlayer.stopRecorder();
+      }
+
       if (returnSegments !== undefined) {
         return RNAudioRecorderPlayer.stopRecorder(returnSegments);
       } else {

--- a/ios/RNAudioRecorderPlayer.m
+++ b/ios/RNAudioRecorderPlayer.m
@@ -17,7 +17,11 @@ RCT_EXTERN_METHOD(startRecorder:(NSString *)path
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject);
 
-RCT_EXTERN_METHOD(stopRecorder:(RCTPromiseResolveBlock)resolve
+RCT_EXTERN_METHOD(stopRecorderWithNoOptions:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject);
+
+RCT_EXTERN_METHOD(stopRecorder:(BOOL)returnSegments
+                  resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(pauseRecorder:(RCTPromiseResolveBlock)resolve

--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -313,12 +313,6 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
             
             // Only attempt resume if we have the shouldResume flag and aren't already resuming
             if option == AVAudioSession.InterruptionOptions.shouldResume.rawValue && !isResumingFromInterruption {
-                // Rate limit resumption attempts - don't try more than once every 2 seconds
-                if let lastTime = lastInterruptionTime, Date().timeIntervalSince(lastTime) < 2.0 {
-                    print("Ignoring rapid interruption sequence")
-                    return
-                }
-                
                 // Ensure the interruption segment was saved before resuming
                 if !interruptionSegmentSaved && audioRecorder != nil {
                     print("Waiting for interruption segment to be saved before resuming")
@@ -329,7 +323,7 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
                 isResumingFromInterruption = true
                 
                 // Use a timer with a slightly longer delay (1.0 second) for better stability
-                interruptionResumeTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self] _ in
+                interruptionResumeTimer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: false) { [weak self] _ in
                     guard let self = self else { return }
                     
                     do {
@@ -356,6 +350,7 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
                         }
                     } catch {
                         self.isResumingFromInterruption = false
+                        print("Failed to resume recorder: \(error)")
                     }
                 }
             }


### PR DESCRIPTION
This pull request enhances the `react-native-audio-recorder-player` library by adding support for handling audio recording interruptions, such as incoming calls, in a seamless way. Previously, when an interruption occurred, resuming the recording would overwrite the existing audio file because `AVAudioRecorder`’s `record()` method implicitly calls `prepareToRecord()`, creating a new file at the specified URL. This made it impossible to truly "resume" a recording with the existing API.

To address this issue, we’ve introduced a new approach:

- **Segmented Recording:** Instead of recording to a single file, the audio is now split into multiple segment files. Each time recording starts or resumes after an interruption, a new segment is created and tracked in an array.
- **Interruption Handling:** When an interruption begins, the current segment is saved and paused. Once the interruption ends, a new segment starts recording, preserving all previous audio.
- **Merging Segments:** Upon stopping the recording, all segments are combined into a single audio file using `AVMutableComposition`, ensuring no audio is lost.

This solution ensures that recordings remain intact across interruptions, providing a smoother and more reliable experience for users. The changes are implemented in `RNAudioRecorderPlayer.swift`, with updates to key methods like `startRecorder`, `resumeRecorder`, and `stopRecorder`, along with new functions for segment management and merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional returnSegments parameter to stop recording, enabling retrieval of individual segment paths.
  - Improved default recording file naming to unique, timestamped files when no path is provided.

- Bug Fixes
  - Increased stability when stopping recordings, with safer cleanup and recovery if a recorder is already active.
  - Validates recorded files on stop to prevent empty/corrupted outputs.
  - Clearer responses for already playing/paused states to avoid redundant actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->