### PR TITLE
fix: add default cases to prevent iOS enum crash

### DIFF
--- a/ios/AudioRecorderPlayer.swift
+++ b/ios/AudioRecorderPlayer.swift
@@ -500,6 +500,9 @@ public class AudioRecorderPlayerImpl: HybridAudioRecorderPlayerSpec {
         case .medium: return AVAudioQuality.medium.rawValue
         case .high: return AVAudioQuality.high.rawValue
         case .max: return AVAudioQuality.max.rawValue
+        default:
+            // Handle unexpected enum case by returning high quality as default
+            return AVAudioQuality.high.rawValue
         }
     }
     
@@ -519,6 +522,9 @@ public class AudioRecorderPlayerImpl: HybridAudioRecorderPlayerSpec {
         case .amr: return Int(kAudioFormatAMR)
         case .flac: return Int(kAudioFormatFLAC)
         case .mac3, .mac6: return Int(kAudioFormatMPEG4AAC) // Default for unsupported formats
+        default:
+            // Handle unexpected enum case by returning AAC as default
+            return Int(kAudioFormatMPEG4AAC)
         }
     }
     


### PR DESCRIPTION
## Summary
This PR fixes a crash that occurs when using `AVFormatIDKeyIOS` or `AVEncoderAudioQualityKeyIOS` with non-default values in iOS.

## Problem
The app crashes with "EXC_BREAKPOINT: unexpected enum case" error when setting audio quality or format options. This is caused by a bug in Nitro Modules' code generation where the `canConvert` function uses incorrect bounds checking for enums with non-sequential values.

## Root Cause
The Nitro-generated `canConvert` function incorrectly validates enum values:
- It checks if values are between 0 and 4 (number of enum cases)
- But actual enum values are: MIN=0, LOW=32, MEDIUM=64, HIGH=96, MAX=127

When JavaScript passes a valid value like 96 (HIGH), the validation fails and throws an exception.

## Solution
Added `default` cases to Swift switch statements to handle unexpected enum values gracefully:
- `mapToAVAudioQuality`: Returns `.high` quality as fallback
- `getAudioFormatID`: Returns AAC format as fallback

This prevents crashes while we wait for the upstream fix in Nitro Modules.

## Related Issues
- Fixes #671
- Reported to Nitro Modules: https://github.com/mrousavy/nitro/issues/764

## Test Plan
1. Set audio quality in recording options:
```javascript
const audioSet = {
  AVEncoderAudioQualityKeyIOS: AVEncoderAudioQualityIOSType.high,
  AVFormatIDKeyIOS: 'aac',
};
await AudioRecorderPlayer.startRecorder(undefined, audioSet, true);
```
2. Verify recording starts without crashing
3. Test with different quality levels and formats