### PR TITLE
fix: make `AudioRecorderPlayerImpl` internal to prevent Swift build errors

### DIFF
--- a/ios/AudioRecorderPlayer.swift
+++ b/ios/AudioRecorderPlayer.swift
@@ -2,7 +2,7 @@ import Foundation
 import AVFoundation
 import NitroModules
 
-public class AudioRecorderPlayerImpl: HybridAudioRecorderPlayerSpec {
+class AudioRecorderPlayerImpl: HybridAudioRecorderPlayerSpec {
     private var audioRecorder: AVAudioRecorder?
     private var audioPlayer: AVAudioPlayer?
     private var audioEngine: AVAudioEngine?


### PR DESCRIPTION
The actual implementation of this should probably be `internal`.
If it is `public`, Swift (or CocoaPods) is a bit stupid; it will try to expose this to C++. If it does that, then it might cause cyclic references or unknown symbols.

Unless you have a reason to make this `public`, we can keep it `internal`.