### PR TITLE
fix: config ndkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,8 @@ android {
   defaultConfig {
     minSdk getExtOrIntegerDefault("minSdkVersion")
     targetSdk getExtOrIntegerDefault("targetSdkVersion")
+    ndkVersion getExtOrDefault("ndkVersion")
+
 
     externalNativeBuild {
       cmake {


### PR DESCRIPTION
Choose ndkVersion from ext first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build configuration to support externalized NDK version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->