### PR TITLE
fix: safe Double→Int conversion to prevent crash from corrupted std::optional<double>

### DIFF
--- a/ios/Sound.swift
+++ b/ios/Sound.swift
@@ -710,6 +710,15 @@ final class HybridSound: HybridSoundSpec_base, HybridSoundSpec_protocol {
 
     // MARK: - Private Methods
 
+    /// Safe Double→Int conversion that handles corrupted std::optional<double>
+    /// values from NitroModules C++ interop (swiftlang/swift#85735).
+    /// Returns nil for NaN, infinity, or out-of-range values instead of trapping.
+    private func safeInt(_ value: Double?) -> Int? {
+        guard let v = value, v.isFinite,
+              v >= Double(Int.min), v <= Double(Int.max) else { return nil }
+        return Int(v)
+    }
+
     private func getAudioSettings(audioSets: AudioSet?) -> [String: Any] {
         var settings: [String: Any] = [:]
 
@@ -724,25 +733,25 @@ final class HybridSound: HybridSoundSpec_base, HybridSoundSpec_protocol {
         settings[AVEncoderBitRateKey] = defaults.bitrate
         settings[AVEncoderAudioQualityKey] = defaults.encoderQuality.rawValue
 
-        // Apply custom settings with explicit overrides taking precedence
+        // Apply custom settings with explicit overrides taking precedence.
+        // All Double→Int conversions use safeInt() to guard against corrupted
+        // std::optional<double> values from NitroModules C++ interop bug.
         if let audioSets = audioSets {
             // iOS-specific settings take highest priority
-            if let sampleRate = audioSets.AVSampleRateKeyIOS {
+            if let sampleRate = safeInt(audioSets.AVSampleRateKeyIOS) {
                 settings[AVSampleRateKey] = sampleRate
-            } else if let audioSamplingRate = audioSets.AudioSamplingRate {
-                // Fall back to cross-platform setting
-                settings[AVSampleRateKey] = Int(audioSamplingRate)
+            } else if let audioSamplingRate = safeInt(audioSets.AudioSamplingRate) {
+                settings[AVSampleRateKey] = audioSamplingRate
             }
 
-            if let channels = audioSets.AVNumberOfChannelsKeyIOS {
-                settings[AVNumberOfChannelsKey] = Int(channels)
-            } else if let audioChannels = audioSets.AudioChannels {
-                // Fall back to cross-platform setting
-                settings[AVNumberOfChannelsKey] = Int(audioChannels)
+            if let channels = safeInt(audioSets.AVNumberOfChannelsKeyIOS) {
+                settings[AVNumberOfChannelsKey] = channels
+            } else if let audioChannels = safeInt(audioSets.AudioChannels) {
+                settings[AVNumberOfChannelsKey] = audioChannels
             }
 
-            if let bitRate = audioSets.AudioEncodingBitRate {
-                settings[AVEncoderBitRateKey] = Int(bitRate)
+            if let bitRate = safeInt(audioSets.AudioEncodingBitRate) {
+                settings[AVEncoderBitRateKey] = bitRate
             }
 
             if let quality = audioSets.AVEncoderAudioQualityKeyIOS {


### PR DESCRIPTION
## Summary

- Adds a `safeInt()` helper to `Sound.swift` that validates Double values before converting to Int
- Wraps all `Int(double)` calls in `getAudioSettings()` with `safeInt()` so corrupted values return `nil` and fall back to quality-preset defaults

## Problem

In iOS Release builds, Swift 6 C++ interop ([swiftlang/swift#85735](https://github.com/swiftlang/swift/issues/85735)) can corrupt `std::optional<double>` memory in the generated `AudioSet` struct. This causes:

1. `.has_value()` returns `true` for empty optionals
2. `.pointee` returns garbage Double values (NaN, infinity, huge numbers)
3. `Int(garbageDouble)` traps with `EXC_BREAKPOINT (SIGTRAP)`: *"Double value cannot be converted to Int because the result would be greater than Int.max"*

The crash occurs in `getAudioSettings()` when any `std::optional<double>` field from `AudioSet` is read and converted via `Int()`. Enum-type `std::optional` fields are unaffected — only `double` and `bool` optionals are corrupted.

## Fix

The `safeInt()` helper checks that the Double is:
- Non-nil
- Finite (not NaN or infinity)  
- Within `Int` range

If any check fails, it returns `nil`, so the existing default from `qualityPresets` is used. Valid values pass through normally.

## Reproduction

1. Configure `AudioSet` with any numeric iOS fields (`AVSampleRateKeyIOS`, `AVNumberOfChannelsKeyIOS`, etc.)
2. Build in **Release mode** (Debug works fine — less aggressive optimization)
3. Start recording → crash in `getAudioSettings()`

## Test plan

- [x] Verified fix in Release build on iOS simulator
- [x] Verified fix in Release build on physical device (TestFlight)
- [ ] Debug build still works (no behavior change for valid values)

## Patch (for patch-package users)

Until this is released, you can use this patch with [patch-package](https://github.com/ds300/patch-package):

<details>
<summary>react-native-nitro-sound+0.2.12.patch</summary>

```diff
diff --git a/node_modules/react-native-nitro-sound/ios/Sound.swift b/node_modules/react-native-nitro-sound/ios/Sound.swift
index 561bb76..ed8b7ce 100644
--- a/node_modules/react-native-nitro-sound/ios/Sound.swift
+++ b/node_modules/react-native-nitro-sound/ios/Sound.swift
@@ -710,6 +710,15 @@ final class HybridSound: HybridSoundSpec_base, HybridSoundSpec_protocol {
 
     // MARK: - Private Methods
 
+    /// Safe Double→Int conversion that handles corrupted std::optional<double>
+    /// values from NitroModules C++ interop (swiftlang/swift#85735).
+    /// Returns nil for NaN, infinity, or out-of-range values instead of trapping.
+    private func safeInt(_ value: Double?) -> Int? {
+        guard let v = value, v.isFinite,
+              v >= Double(Int.min), v <= Double(Int.max) else { return nil }
+        return Int(v)
+    }
+
     private func getAudioSettings(audioSets: AudioSet?) -> [String: Any] {
         var settings: [String: Any] = [:]
 
@@ -724,25 +733,25 @@ final class HybridSound: HybridSoundSpec_base, HybridSoundSpec_protocol {
         settings[AVEncoderBitRateKey] = defaults.bitrate
         settings[AVEncoderAudioQualityKey] = defaults.encoderQuality.rawValue
 
-        // Apply custom settings with explicit overrides taking precedence
+        // Apply custom settings with explicit overrides taking precedence.
+        // All Double→Int conversions use safeInt() to guard against corrupted
+        // std::optional<double> values from NitroModules C++ interop bug.
         if let audioSets = audioSets {
             // iOS-specific settings take highest priority
-            if let sampleRate = audioSets.AVSampleRateKeyIOS {
+            if let sampleRate = safeInt(audioSets.AVSampleRateKeyIOS) {
                 settings[AVSampleRateKey] = sampleRate
-            } else if let audioSamplingRate = audioSets.AudioSamplingRate {
-                // Fall back to cross-platform setting
-                settings[AVSampleRateKey] = Int(audioSamplingRate)
+            } else if let audioSamplingRate = safeInt(audioSets.AudioSamplingRate) {
+                settings[AVSampleRateKey] = audioSamplingRate
             }
 
-            if let channels = audioSets.AVNumberOfChannelsKeyIOS {
-                settings[AVNumberOfChannelsKey] = Int(channels)
-            } else if let audioChannels = audioSets.AudioChannels {
-                // Fall back to cross-platform setting
-                settings[AVNumberOfChannelsKey] = Int(audioChannels)
+            if let channels = safeInt(audioSets.AVNumberOfChannelsKeyIOS) {
+                settings[AVNumberOfChannelsKey] = channels
+            } else if let audioChannels = safeInt(audioSets.AudioChannels) {
+                settings[AVNumberOfChannelsKey] = audioChannels
             }
 
-            if let bitRate = audioSets.AudioEncodingBitRate {
-                settings[AVEncoderBitRateKey] = Int(bitRate)
+            if let bitRate = safeInt(audioSets.AudioEncodingBitRate) {
+                settings[AVEncoderBitRateKey] = bitRate
             }
 
             if let quality = audioSets.AVEncoderAudioQualityKeyIOS {
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced iOS audio configuration stability by implementing safeguards against corrupted audio settings values that could previously cause runtime crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->