### PR TITLE
fix: make stopRecorder idempotent

### DIFF
--- a/android/src/main/java/com/margelo/nitro/audiorecorderplayer/Sound.kt
+++ b/android/src/main/java/com/margelo/nitro/audiorecorderplayer/Sound.kt
@@ -288,7 +288,18 @@ class HybridSound : HybridSoundSpec() {
         // Return immediately and process in background
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                mediaRecorder?.apply {
+                val recorder = mediaRecorder
+                if (recorder == null) {
+                    // stopRecorder is idempotent: a second call after the recorder
+                    // was already stopped is a no-op instead of an error (#789).
+                    handler.post {
+                        stopRecordTimer()
+                    }
+                    promise.resolve("recorder already stopped")
+                    return@launch
+                }
+
+                recorder.apply {
                     stop()
                     release()
                 }

--- a/ios/Sound.swift
+++ b/ios/Sound.swift
@@ -428,7 +428,9 @@ final class HybridSound: HybridSoundSpec_base, HybridSoundSpec_protocol {
                     }
                 }
             } else {
-                promise.reject(withError: RuntimeError.error(withMessage: "No recorder instance"))
+                // stopRecorder is idempotent: a second call after the recorder
+                // was already stopped is a no-op instead of an error (#789).
+                promise.resolve(withResult: "recorder already stopped")
             }
         }
 


### PR DESCRIPTION
## Summary
- `stopRecorder()` rejected when called after the recorder was already stopped — iOS with `No recorder instance`, Android with `Recorder not started or path is unavailable`. Apps commonly call it defensively from cleanup paths (unmount effects, error handlers), and the legacy `react-native-audio-recorder-player` treated repeated calls as a no-op.
- Both platforms now resolve with `"recorder already stopped"` on repeated calls; the first call still resolves with the recording's file URI.

Closes #789

## Test plan
- [x] `yarn typecheck` / `yarn lint` / `yarn test`
- [ ] iOS example builds (CI)
- [ ] Android example builds (CI)
- Repro from #789: `startRecorder()` → `stopRecorder()` → `stopRecorder()` resolves instead of rejecting/hanging.

🤖 Autogenerated by Claude (AI-native maintenance).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recorder stopping behavior when recording has already stopped.
  * Stopping an inactive recorder now completes successfully without displaying an error.
  * Ensured recording timers are stopped correctly in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->