### PR TITLE
fix(android): force 16 KB page-size alignment for libNitroSound.so

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -35,3 +35,13 @@ target_link_libraries(
         ${LOG_LIB}
         android # <-- Android core
 )
+
+# 16 KB page-size alignment (Google Play requirement since Nov 2025).
+# ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES in build.gradle only takes effect on
+# NDK r27+, but this library compiles inside the consumer's app with the
+# consumer's NDK — apps on React Native <= 0.79 default to NDK 26, which
+# produced a 4 KB-aligned libNitroSound.so. Passing the linker flag directly
+# guarantees alignment on every NDK version (it is a no-op where already set).
+# set_property is used instead of target_link_options to stay compatible with
+# the declared cmake_minimum_required(3.9).
+set_property(TARGET ${PACKAGE_NAME} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-z,max-page-size=16384")


### PR DESCRIPTION
## Summary
- The repo already sets `ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` (since 0.2.10 / #663), but that CMake variable only works on **NDK r27+**. This library compiles from source inside the consumer's app with the consumer's NDK — React Native ≤ 0.79 defaults to NDK 26, so those apps still shipped a 4 KB-aligned `libNitroSound.so` and failed the Google Play 16 KB page-size check (exactly the setup in #747: RN 0.79.6 + lib 0.2.10).
- Appending `-Wl,-z,max-page-size=16384` directly to the linker flags guarantees 16 KB alignment on every NDK version; it's a no-op where alignment is already in effect. `set_property(... LINK_FLAGS ...)` is used to stay compatible with the declared `cmake_minimum_required(3.9)`.

Closes #747

## Test plan
- [x] `yarn typecheck` / `yarn lint` / `yarn test`
- [ ] Android example builds (CI)
- Verify: `Analyze APK` in Android Studio (or `check_elf_alignment.sh`) reports `libNitroSound.so` as 16 KB-aligned even when building with NDK 26.

🤖 Autogenerated by Claude (AI-native maintenance).