### PR TITLE
fix(android): support android.resource:// URIs in startPlayer

### DIFF
--- a/android/src/main/java/com/margelo/nitro/audiorecorderplayer/Sound.kt
+++ b/android/src/main/java/com/margelo/nitro/audiorecorderplayer/Sound.kt
@@ -422,8 +422,10 @@ class HybridSound : HybridSoundSpec() {
                         val headers = httpHeaders ?: emptyMap()
                         setDataSource(context, Uri.parse(uri), headers)
                     }
-                    uri.startsWith("content://") -> {
-                        // Handle content URI
+                    uri.startsWith("content://") || uri.startsWith("android.resource://") -> {
+                        // Content and bundled-resource URIs must resolve through a
+                        // Context; treating android.resource:// as a plain file path
+                        // fails with 'Prepare failed: status=0x1' (#751).
                         setDataSource(context, Uri.parse(uri))
                     }
                     uri.startsWith("file://") -> {


### PR DESCRIPTION
## Summary
- `android.resource://<package>/raw/<name>` URIs fell into the plain-file-path branch of `startPlayer`, so `MediaPlayer.setDataSource(String)` threw `java.io.IOException: Prepare failed.: status=0x1` — the exact error @AnasAzamMaher hit in #751 when following the res/raw workaround.
- They now resolve through `setDataSource(Context, Uri)` like `content://` URIs, so bundled res/raw audio plays in release builds where Metro asset paths are not real files on disk.

This addresses the release-build playback path from #751. The debug-vs-release difference in `Image.resolveAssetSource` output is app-side (Metro serves a URL in debug, a resource name in release), so the recommended pattern for bundled sounds on Android release builds is an `android.resource://` URI — which now works out of the box.

Refs #751

## Test plan
- [x] `yarn typecheck` / `yarn lint` / `yarn test`
- [ ] Android example builds (CI)
- Manual: `startPlayer('android.resource://<appId>/raw/<sound>')` plays in a release build.

🤖 Autogenerated by Claude (AI-native maintenance).