### PR TITLE
fix(ios): bound channel count by what the input route supports

### DIFF
--- a/ios/Sound.swift
+++ b/ios/Sound.swift
@@ -743,12 +743,12 @@ final class HybridSound: HybridSoundSpec_base, HybridSoundSpec_protocol {
     }
 
     // isFinite alone is not enough: a corrupted std::optional<double> can carry
-    // finite garbage (e.g. 5e-15 or 1e18) that passes the `> 0` check, reaches
-    // AudioQueueNew, and gets rejected as 'fmt?' — prepareToRecord() then fails,
-    // but only in optimized release builds (#766). Values outside the range any
-    // iOS codec accepts are dropped in favor of the quality-preset defaults.
+    // finite garbage (subnormals like 5e-324, or a plain wrong value) that passes
+    // the `> 0` check, reaches AudioQueueNew, and gets rejected as 'fmt?' —
+    // prepareToRecord() then fails, but only in optimized release builds (#766).
+    // Upstream tracking: mrousavy/nitro#1319 (still open). Values outside the
+    // range any iOS codec accepts are dropped in favor of the quality presets.
     private static let validSampleRateRange = 4_000.0...192_000.0
-    private static let validChannelRange = 1...8
     private static let validBitRateRange = 8_000...1_536_000
 
     private func validSampleRate(_ value: Double?) -> Double? {
@@ -756,8 +756,21 @@ final class HybridSound: HybridSoundSpec_base, HybridSoundSpec_protocol {
         return v
     }
 
+    /// Upper bound for a requested channel count.
+    ///
+    /// A corrupted value can land inside a plausible range — release builds have
+    /// been observed recording 5-channel 5.0 surround files from a phone mic
+    /// (#741, #736), which a fixed 1...8 check would happily accept. Bounding by
+    /// what the current input route can actually deliver rejects that while
+    /// still allowing genuine multi-channel hardware. The floor of 2 keeps the
+    /// built-in mono mic (maximumInputNumberOfChannels == 1) working with the
+    /// stereo `.high` preset, which AVAudioRecorder upmixes as it always has.
+    private func maxAllowedChannels() -> Int {
+        max(2, AVAudioSession.sharedInstance().maximumInputNumberOfChannels)
+    }
+
     private func validChannelCount(_ value: Double?) -> Int? {
-        guard let v = safeInt(value), Self.validChannelRange.contains(v) else { return nil }
+        guard let v = safeInt(value), v >= 1, v <= maxAllowedChannels() else { return nil }
         return v
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #832, from re-reading the closed-issue history (#741, #736).

The upstream repro (mrousavy/nitro#1319, **still open**) shows corrupted optionals surfacing two ways in iOS Release builds: fields *drop* (tag bits read as "not present") and fields *carry garbage* — subnormals like `5e-324`, but also plain wrong values. @felixspitzer's release log in #736 captured both at once:

```
AVSampleRateKeyIOS: nil                       ← was 22050 in debug
AVNumberOfChannelsKeyIOS: Optional(5.0)       ← was 2 in debug
AudioSamplingRate: Optional(-nan(0x30070002ade90))
```

`#832`'s range checks reject the `nan` and the subnormals, but **`5` passes a fixed `1...8` check** — which is exactly the `5 ch, 44100 Hz` 5.0-surround file both #741 and #736 ended up with. So that symptom would have survived 0.2.16.

This bounds the requested channel count by `AVAudioSession.maximumInputNumberOfChannels` (what the current input route can actually deliver) with a floor of 2:
- iPhone built-in mic (`maximumInputNumberOfChannels == 1`) → cap 2 → a corrupted `5` is rejected and the quality preset is used; the stereo `.high` preset still works exactly as before (AVAudioRecorder upmixes mono input, unchanged behavior).
- Multi-channel USB/Lightning interfaces → cap follows the hardware, so genuine 4/8-channel recording is unaffected.

Also corrects the stale code comment: the root cause is tracked upstream at mrousavy/nitro#1319, which is open — no nitro-modules release fixes it yet, so this validation is the library's only defense.

Refs #741, #736, #766

## Test plan
- [x] `yarn typecheck` / `yarn lint` / `yarn test`
- [ ] iOS example builds (CI)
- [ ] Android example builds (CI)
- Field verification: record in a Release/TestFlight build with `AVNumberOfChannelsKeyIOS: 2` and confirm `afinfo` reports `2 ch` rather than `5 ch`.

🤖 Autogenerated by Claude (AI-native maintenance).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio input validation for corrupted or unsupported sample-rate values.
  * Updated channel validation to reflect the active input route while supporting at least two channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->