### PR TITLE
fix: return the recording URI from repeated stopRecorder calls

### DIFF
--- a/android/src/main/java/com/margelo/nitro/audiorecorderplayer/Sound.kt
+++ b/android/src/main/java/com/margelo/nitro/audiorecorderplayer/Sound.kt
@@ -26,6 +26,10 @@ class HybridSound : HybridSoundSpec() {
     private var mediaPlayer: MediaPlayer? = null
     private var currentRecordingPath: String? = null
 
+    // Returned by repeated stopRecorder() calls so every call yields the same
+    // file URI instead of a sentinel string a caller could mistake for a path.
+    private var lastRecordingUri: String? = null
+
     private var recordTimer: Timer? = null
     private var playTimer: Timer? = null
 
@@ -291,11 +295,13 @@ class HybridSound : HybridSoundSpec() {
                 val recorder = mediaRecorder
                 if (recorder == null) {
                     // stopRecorder is idempotent: a second call after the recorder
-                    // was already stopped is a no-op instead of an error (#789).
+                    // was already stopped resolves with the same URI as the first
+                    // one, so a double-tapped stop button cannot hand the caller a
+                    // sentinel string where it expects a file path (#789, #693).
                     handler.post {
                         stopRecordTimer()
                     }
-                    promise.resolve("recorder already stopped")
+                    promise.resolve(lastRecordingUri ?: "recorder already stopped")
                     return@launch
                 }
 
@@ -317,8 +323,9 @@ class HybridSound : HybridSoundSpec() {
                 val path = currentRecordingPath
                 currentRecordingPath = null // State is cleared regardless of outcome
                 
-                path?.let { 
+                path?.let {
                     val fileUri = Uri.fromFile(File(it)).toString()
+                    lastRecordingUri = fileUri
                     promise.resolve(fileUri)
                 } ?: promise.reject(Exception("Recorder not started or path is unavailable."))
             } catch (e: Exception) {

--- a/ios/Sound.swift
+++ b/ios/Sound.swift
@@ -40,6 +40,9 @@ final class HybridSound: HybridSoundSpec_base, HybridSoundSpec_protocol {
     private var subscriptionDuration: TimeInterval = 0.06
     private var playbackRate: Double = 1.0 // default 1x
     private var recordingSession: AVAudioSession?
+    // Returned by repeated stopRecorder() calls so every call yields the same
+    // file URI instead of a sentinel string a caller could mistake for a path.
+    private var lastRecordingURI: String?
 
     // MARK: - Recording Methods
 
@@ -414,6 +417,7 @@ final class HybridSound: HybridSoundSpec_base, HybridSoundSpec_protocol {
 
             if let recorder = self.audioRecorder {
                 let url = recorder.url.absoluteString
+                self.lastRecordingURI = url
 
                 // Stop recorder on main queue
                 DispatchQueue.main.async {
@@ -433,8 +437,10 @@ final class HybridSound: HybridSoundSpec_base, HybridSoundSpec_protocol {
                 }
             } else {
                 // stopRecorder is idempotent: a second call after the recorder
-                // was already stopped is a no-op instead of an error (#789).
-                promise.resolve(withResult: "recorder already stopped")
+                // was already stopped resolves with the same URI as the first
+                // one, so a double-tapped stop button cannot hand the caller a
+                // sentinel string where it expects a file path (#789, #693).
+                promise.resolve(withResult: self.lastRecordingURI ?? "recorder already stopped")
             }
         }
 


### PR DESCRIPTION
## Summary
Follow-up to #831, from re-reading the closed-issue history (#693, #649).

#831 made `stopRecorder()` idempotent by resolving repeat calls with the literal string `"recorder already stopped"`. But a **double-tapped stop button** is precisely why callers reach that path, and the common pattern

```js
const uri = await stopRecorder();
upload(uri);
```

would then upload a sentinel string instead of throwing the way it did before 0.2.16 — trading a loud failure for a silent one.

Both platforms now remember the last recording's URI and return it for repeat calls, so every call yields the same value (genuinely idempotent, not just non-throwing). The sentinel string remains only when `stopRecorder` is called before anything has ever been recorded.

This also lines up with the convention settled in #693, where it was agreed that `stopRecorder` should return a full file URI consistently on both platforms.

## Test plan
- [x] `yarn typecheck` / `yarn lint` / `yarn test`
- [ ] iOS example builds (CI)
- [ ] Android example builds (CI)
- Manual: `startRecorder()` → `stopRecorder()` → `stopRecorder()` returns the same `file://…` URI twice.

🤖 Autogenerated by Claude (AI-native maintenance).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stopping a recording multiple times now consistently returns the recorded file location when available.
  * Improved playback support for Android content and bundled resource audio locations.
  * Recording results are now preserved consistently across platforms for more reliable follow-up playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->