### PR TITLE
docs: correct 0.2.18 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,25 @@
 
 ## [0.2.18] — 2026-08-07
 
+```sh
+yarn add react-native-nitro-sound@0.2.18
+```
 
-### 🔧 Maintenance Release
+### 🐛 Reliability fixes
 
-This release contains dependency updates and internal improvements only.
+- Harden Android `MediaPlayer` ownership and cleanup so stale callbacks from replaced players cannot settle newer playback operations. ([#838](https://github.com/hyochan/react-native-nitro-sound/pull/838))
+- Use the current iOS Bluetooth HFP audio-session category option consistently across recorder and player setup. ([#838](https://github.com/hyochan/react-native-nitro-sound/pull/838))
+- Remove obsolete Android external-storage permission requests and consolidate microphone permission handling in the example app. ([#838](https://github.com/hyochan/react-native-nitro-sound/pull/838))
+
+### ⚙️ Compatibility and tooling
+
+- Move the supported iOS build baseline to Xcode 26.0+ and align CI, CocoaPods setup, and compatibility documentation.
+- Align development and example tooling with Node 22, Yarn 4.18, React Native 0.86.2, and Nitro 0.36.5. The published peer dependency now requires `react-native-nitro-modules >=0.36.5`.
+
+### 🧪 Verification
+
+- Expand native and Web unit coverage and add guarded Simulator audio regression flows for recorder and player state transitions.
+- The iOS Simulator lane covered record, pause/resume, stop, play, pause/resume, and stop. Bluetooth routing, interruptions, backgrounding, route changes, audio focus, physical-device-only behavior, and audible fidelity remain outside Simulator coverage.
 
 ---
 


### PR DESCRIPTION
## Summary

- replace the generated maintenance-only 0.2.18 changelog entry with the actual user-facing reliability and compatibility changes
- restore the 0.2.18 installation snippet
- document the verified Simulator scope without implying physical-device coverage

## Context

The 0.2.18 package, tag, and GitHub Release were published successfully. The squash commit used a `chore:` subject, so the automated release-note generator omitted the Android player-lifecycle and iOS Bluetooth HFP changes. The GitHub Release body has already been corrected; this PR aligns the repository changelog without changing the published package or tag.

## Validation

- `git diff --check`
- commit-hook typecheck
- manual Markdown and link review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the 0.2.18 release notes with installation guidance and details on reliability improvements.
  - Documented compatibility and tooling updates, verification coverage, and known limitations for Simulator testing.
  - Replaced the previous maintenance-release description with more complete and accurate information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->